### PR TITLE
Put extra filters before ones from the query

### DIFF
--- a/QueryFilter/QueryFilter.php
+++ b/QueryFilter/QueryFilter.php
@@ -209,7 +209,7 @@ class QueryFilter
 
         // Set search extra filters (can be used to display entries for one particular entity,
         // or to add some extra conditions/filterings)
-        $searchBy = array_merge($searchBy, $config->getSearchByExtra());
+        $searchBy = array_merge($config->getSearchByExtra(), $searchBy);
 
         return $searchBy;
     }


### PR DESCRIPTION
This kinda fixes #8 for my case, although the result still remains very fragile: a single `OR` in the HTTP query will break the logic.

There are certainly better ways to fix the problem, but I can't come up with one that would not change the API at all.