### PR TITLE
Allow symfony 6

### DIFF
--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -12,7 +12,7 @@ jobs:
     strategy:
       matrix:
         operating-system: [ubuntu-latest]
-        php-versions: ['7.3', '7.4', '8.0']
+        php-versions: ['8.0', '8.1']
     name: PHP ${{ matrix.php-versions }} Test on ${{ matrix.operating-system }}
     steps:
     - name: Checkout

--- a/.github/workflows/symfony.yml
+++ b/.github/workflows/symfony.yml
@@ -23,8 +23,8 @@ jobs:
     strategy:
       matrix:
         operating-system: [ubuntu-latest]
-        symfony-versions: ['4.4', '5.2', '5.3']
-        php-versions: ['7.3', '7.4', '8.0']
+        symfony-versions: ['4.4', '5.4', '6.0']
+        php-versions: ['8.0', '8.1']
     name: PHP ${{ matrix.php-versions }} / Symfony ${{ matrix.symfony-versions }} Test on ${{ matrix.operating-system }}
     steps:
     - name: Checkout

--- a/Query/ConditionManager.php
+++ b/Query/ConditionManager.php
@@ -15,7 +15,7 @@ class ConditionManager implements \ArrayAccess, \Iterator
     /**
      * @var ConditionInterface[]
      */
-    private $conditions = [];
+    private array $conditions = [];
 
     public function wrapQueryBuilder(QueryBuilder $qb): ProxyQueryBuilder
     {
@@ -35,17 +35,17 @@ class ConditionManager implements \ArrayAccess, \Iterator
         return $this->conditions;
     }
 
-    public function offsetExists($offset)
+    public function offsetExists($offset): bool
     {
         return array_key_exists($offset, $this->conditions);
     }
 
-    public function offsetGet($offset)
+    public function offsetGet($offset): mixed
     {
         return $this->offsetExists($offset) ? $this->conditions[$offset] : null;
     }
 
-    public function offsetSet($offset, $value)
+    public function offsetSet($offset, $value): void
     {
         if ($offset === null) {
             $this->conditions[] = $value;
@@ -54,27 +54,27 @@ class ConditionManager implements \ArrayAccess, \Iterator
         }
     }
 
-    public function offsetUnset($offset) {
+    public function offsetUnset($offset): void {
         unset($this->conditions[$offset]);
     }
 
-    public function rewind() {
-        return reset($this->conditions);
+    public function rewind(): void {
+        reset($this->conditions);
     }
 
-    public function current() {
+    public function current(): mixed {
         return current($this->conditions);
     }
 
-    public function key() {
+    public function key(): mixed {
         return key($this->conditions);
     }
 
-    public function next() {
-        return next($this->conditions);
+    public function next(): void {
+        next($this->conditions);
     }
 
-    public function valid() {
+    public function valid(): bool {
         return key($this->conditions) !== null;
     }
 }

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 | [![Coverage Status][Master coverage image]][Master coverage] |
 | [![Quality Status][Master quality image]][Master quality] |
 
-Query Filter Bundle for Symfony 4.3 and Symfony 5
+Query Filter Bundle for Symfony 4.3, Symfony 5 and Symfony 6
 =================================================
 
 Query Filter Bundle brings request filtering and pagination functionality to Symfony 4.3 / 5 applications that use Doctrine 2.

--- a/Request/Request.php
+++ b/Request/Request.php
@@ -3,6 +3,7 @@
 namespace Artprima\QueryFilterBundle\Request;
 
 use Artprima\QueryFilterBundle\Exception\InvalidArgumentException;
+use Symfony\Component\HttpFoundation\Exception\BadRequestException;
 use Symfony\Component\HttpFoundation\Request as HttpRequest;
 
 /**
@@ -49,18 +50,42 @@ final class Request
      */
     public function __construct(HttpRequest $request)
     {
-        $this->pageNum = (int)$request->query->get('page', 1);
-        $this->limit = (int)$request->query->get('limit', -1);
-        $this->query = $request->query->all('filter');
-        if ($this->query !== null && !is_array($this->query)) {
+        try {
+            $this->pageNum = (int)$request->query->get('page', 1);
+        } catch (BadRequestException) {
+            throw new InvalidArgumentException('Query page must be scalar');
+        }
+        try {
+            $this->limit = (int)$request->query->get('limit', -1);
+        } catch (BadRequestException) {
+            throw new InvalidArgumentException('Query limit must be scalar');
+        }
+        try {
+            $this->query = $request->query->all('filter');
+        } catch (BadRequestException) {
             throw new InvalidArgumentException('Query filter must be an array');
         }
-        $this->sortBy = $request->query->get('sortby');
-        $this->sortDir = $request->query->get('sortdir', 'asc');
+        try {
+            $this->sortBy = $request->query->get('sortby');
+        } catch (BadRequestException) {
+            throw new InvalidArgumentException('Query sort by must be scalar');
+        }
+        if (null !== $this->sortBy && !is_string($this->sortBy)) {
+            throw new InvalidArgumentException('Query sort by must be a string');
+        }
+        try {
+            $this->sortDir = $request->query->get('sortdir', 'asc');
+        } catch (BadRequestException) {
+            throw new InvalidArgumentException('Query sort direction must be scalar');
+        }
         if (!is_string($this->sortDir)) {
             throw new InvalidArgumentException('Query sort direction must be a string');
         }
-        $this->simple = (bool)$request->query->get('simple', '1');
+        try {
+            $this->simple = (bool)$request->query->get('simple', '1');
+        } catch (BadRequestException) {
+            throw new InvalidArgumentException('Query simple must be scalar');
+        }
     }
 
     /**

--- a/Request/Request.php
+++ b/Request/Request.php
@@ -51,7 +51,7 @@ final class Request
     {
         $this->pageNum = (int)$request->query->get('page', 1);
         $this->limit = (int)$request->query->get('limit', -1);
-        $this->query = $request->query->get('filter');
+        $this->query = $request->query->all('filter');
         if ($this->query !== null && !is_array($this->query)) {
             throw new InvalidArgumentException('Query filter must be an array');
         }

--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,7 @@
     }
   ],
   "require": {
-    "php": ">=7.3.0",
+    "php": ">=8.0.0",
     "symfony/http-kernel": "^4.4|^5.2|^6.0",
     "symfony/dependency-injection": "^4.4|^5.2|^6.0",
     "symfony/config": "^4.4|^5.2|^6.0",

--- a/composer.json
+++ b/composer.json
@@ -12,9 +12,9 @@
   ],
   "require": {
     "php": ">=7.3.0",
-    "symfony/http-kernel": "^4.4|^5.2",
-    "symfony/dependency-injection": "^4.4|^5.2",
-    "symfony/config": "^4.4|^5.2",
+    "symfony/http-kernel": "^4.4|^5.2|^6.0",
+    "symfony/dependency-injection": "^4.4|^5.2|^6.0",
+    "symfony/config": "^4.4|^5.2|^6.0",
     "doctrine/orm": "^2.7",
     "doctrine/persistence": "^2.0",
     "sensio/framework-extra-bundle": "^5.1.5|^6.0",

--- a/tests/unit/Request/RequestTest.php
+++ b/tests/unit/Request/RequestTest.php
@@ -4,8 +4,8 @@ namespace Tests\Unit\Artprima\QueryFilterBundle\Request;
 
 use Artprima\QueryFilterBundle\Exception\InvalidArgumentException;
 use Artprima\QueryFilterBundle\Request\Request;
-use Symfony\Component\HttpFoundation\Request as HttpRequest;
 use PHPUnit\Framework\TestCase;
+use Symfony\Component\HttpFoundation\Request as HttpRequest;
 
 class RequestTest extends TestCase
 {
@@ -109,7 +109,37 @@ class RequestTest extends TestCase
         self::assertSame(true, $request->isSimple());
     }
 
-    public function testInvalidQueryException()
+    public function testInvalidPageException()
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage("Query page must be scalar");
+        $httpRequest = new HttpRequest(array(
+            'page' => ['42'],
+            'limit' => '4242',
+            'filter' => ['column' => 'value'],
+            'sortby' => 'sortbydummy',
+            'sortdir' => 'desc',
+            'simple' => '0',
+        ));
+        $request = new Request($httpRequest);
+    }
+
+    public function testInvalidLimitException()
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage("Query limit must be scalar");
+        $httpRequest = new HttpRequest(array(
+            'page' => '42',
+            'limit' => ['4242'],
+            'filter' => ['column' => 'value'],
+            'sortby' => 'sortbydummy',
+            'sortdir' => 'desc',
+            'simple' => '0',
+        ));
+        $request = new Request($httpRequest);
+    }
+
+    public function testInvalidQueryException1()
     {
         $this->expectException(InvalidArgumentException::class);
         $this->expectExceptionMessage("Query filter must be an array");
@@ -118,6 +148,51 @@ class RequestTest extends TestCase
             'limit' => '4242',
             'filter' => 'string',
             'sortby' => 'sortbydummy',
+            'sortdir' => 'desc',
+            'simple' => '0',
+        ));
+        $request = new Request($httpRequest);
+    }
+
+    /**
+     * @doesNotPerformAssertions should not throw exceptions when filter is missing
+     */
+    public function testInvalidQueryException2()
+    {
+        $httpRequest = new HttpRequest(array(
+            'page' => '42',
+            'limit' => '4242',
+            'sortby' => 'sortbydummy',
+            'sortdir' => 'desc',
+            'simple' => '0',
+        ));
+        $request = new Request($httpRequest);
+    }
+
+    public function testInvalidSortByException1()
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage("Query sort by must be scalar");
+        $httpRequest = new HttpRequest(array(
+            'page' => '42',
+            'limit' => '4242',
+            'filter' => ['column' => 'value'],
+            'sortby' => ['sortbydummy'],
+            'sortdir' => 'desc',
+            'simple' => '0',
+        ));
+        $request = new Request($httpRequest);
+    }
+
+    public function testInvalidSortByException2()
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage("Query sort by must be a string");
+        $httpRequest = new HttpRequest(array(
+            'page' => '42',
+            'limit' => '4242',
+            'filter' => ['column' => 'value'],
+            'sortby' => 42,
             'sortdir' => 'desc',
             'simple' => '0',
         ));
@@ -143,13 +218,28 @@ class RequestTest extends TestCase
     public function testInvalidSortDirException2()
     {
         $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('Query sort direction must be scalar');
+        $httpRequest = new HttpRequest(array(
+            'page' => '42',
+            'limit' => '4242',
+            'filter' => ['column' => 'value'],
+            'sortby' => 'sortbydummy',
+            'sortdir' => ['invalid'],
+            'simple' => '0',
+        ));
+        $request = new Request($httpRequest);
+    }
+
+    public function testInvalidSortDirException3()
+    {
+        $this->expectException(InvalidArgumentException::class);
         $this->expectExceptionMessage('Query sort direction must be a string');
         $httpRequest = new HttpRequest(array(
             'page' => '42',
             'limit' => '4242',
             'filter' => ['column' => 'value'],
             'sortby' => 'sortbydummy',
-            'sortdir' => array('invalid'),
+            'sortdir' => 42,
             'simple' => '0',
         ));
         $request = new Request($httpRequest);


### PR DESCRIPTION
These were the changes I've made to allow symfony 6 to work.

The biggest one was `query->all` since `get` checks that the value is scalar and it was throwing an error since it was an array.
The other ones were deprecations for the return types.