### PR TITLE
Add search allowed cols lengths

### DIFF
--- a/Exception/InvalidLengthException.php
+++ b/Exception/InvalidLengthException.php
@@ -1,0 +1,8 @@
+<?php declare(strict_types=1);
+
+namespace Artprima\QueryFilterBundle\Exception;
+
+class InvalidLengthException extends \RuntimeException
+{
+
+}

--- a/QueryFilter/Config/BaseConfig.php
+++ b/QueryFilter/Config/BaseConfig.php
@@ -36,6 +36,7 @@ class BaseConfig implements ConfigInterface
         'args' => [],
         'aliases' => [],
         'extra' => [],
+        'lengths' => [],
     ];
 
     /**
@@ -82,6 +83,24 @@ class BaseConfig implements ConfigInterface
     public function getSearchAllowedCols(): array
     {
         return $this->searchBy['args'];
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function setSearchAllowedColsLengths(array $lengths): ConfigInterface
+    {
+        $this->searchBy['lengths'] = $lengths;
+
+        return $this;
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function getSearchAllowedColsLengths(): array
+    {
+        return $this->searchBy['lengths'];
     }
 
     /**

--- a/QueryFilter/Config/ConfigInterface.php
+++ b/QueryFilter/Config/ConfigInterface.php
@@ -25,6 +25,19 @@ interface ConfigInterface
     public function getSearchAllowedCols(): array;
 
     /**
+     * @param array $lengths
+     * @return $this
+     */
+    public function setSearchAllowedColsLengths(array $lengths): ConfigInterface;
+
+    /**
+     * Get allowed columns lengths
+     *
+     * @return array
+     */
+    public function getSearchAllowedColsLengths(): array;
+
+    /**
      * Set shortcut expanders (aliaces).
      *
      * For example, concat(concat(concat(concat(p.firstname, ' '), p.middlename), ' '), p.lastname) can be

--- a/README.md
+++ b/README.md
@@ -49,6 +49,7 @@ class DefaultController extends Controller
         // set up the config
         $config = new BaseConfig();
         $config->setSearchAllowedCols(['t.name']);
+        $config->setSearchAllowedColsLengths(['t.name' => ['min' => 2, 'max' => 255]]);
         $config->setAllowedLimits([10, 25, 50, 100]);
         $config->setDefaultLimit(10);
         $config->setSortCols(['t.id'], ['t.id' => 'asc']);


### PR DESCRIPTION
`$config->setSearchAllowedColsLengths(['t.name' => ['min' => 2, 'max' => 255]]);`
Is used to set min and max lengths for a column (which is optional) and it wouldnt allow.

In this example, a name which has just 1 character, and not more than 255.