### PR TITLE
Allow doctrine/persistence 3.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,7 @@
     "symfony/dependency-injection": "^4.4|^5.2|^6.0",
     "symfony/config": "^4.4|^5.2|^6.0",
     "doctrine/orm": "^2.7",
-    "doctrine/persistence": "^2.0",
+    "doctrine/persistence": "^2.0|^3.0",
     "sensio/framework-extra-bundle": "^5.1.5|^6.0",
     "doctrine/doctrine-bundle": "^2.2"
   },


### PR DESCRIPTION
In my private symfony 6, php 8.1 project there were no errors (all tests pass)